### PR TITLE
Eigenvector sorting for v1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.2'
+          - '1.0'
           - '1'
           - 'nightly'
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Aqua = "0.5"
 HalfIntegers = "1"
 OffsetArrays = "0.11, 1"
-julia = "1.2"
+julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
Since `eigen!(::Hermitian, sortby = ..)` is only defined for v1.2, it may be implemented by hand for lower Julia versions.